### PR TITLE
adjust rotary condensor recipes regarding polonium containing steam

### DIFF
--- a/kubejs/server_scripts/mods/mekanism_extras/mekanism_extras.js
+++ b/kubejs/server_scripts/mods/mekanism_extras/mekanism_extras.js
@@ -15,23 +15,11 @@ ServerEvents.recipes((event) => {
 	// this one is for steam to solution, normally it goes at 1mb/tick , this would mean you would need 1,500,000 rotary condensers to keep up with the naquadah reactor, and that is absurd
 	// this adjusts it to 5000mb/tick per machine, this lowers it to only needing 300 , this is still a lot but a lot more manageable , also this is assuming max level machines, 16 speed and 16 energy upgrades
 	// no watch of flowing time is taken into account for this , not sure if it affect condensors but it might
-	event.custom({
-		type:"mekanism:rotary",
-		fluidInput: {fluid:"mekanism_extras:polonium_containing_solution",amount:5000},
-		gasOutput: {gas:"mekanism_extras:polonium_containing_steam",amount:5000},
-		gasInput: {gas:"mekanism_extras:polonium_containing_steam",amount:5000},
-		fluidOutput: {fluid:"mekanism_extras:polonium_containing_solution",amount:5000}
-	})
+	customRecipes.mekanism.condensentrating(event,"mekanism_extras:polonium_containing_solution",5000,"mekanism_extras:polonium_containing_steam",5000)
 
 	// this is for going from the liquid polonium 208 to the gas form, this is after the evaporation chamber machine thingy, normally this is again at 1mb/tick per machine
 	// but with a flow rate of 15,000 mb/tick needed, well, 15,000 condensers is again insane, so adjusting them to 300mb/tick per machine means you only need 50 of them for full flow
-	event.custom({
-		type:"mekanism:rotary",
-		fluidInput: {fluid:"mekanism_extras:polonium-208",amount:300},
-		gasOutput: {gas:"mekanism_extras:polonium-208",amount:300},
-		gasInput: {gas:"mekanism_extras:polonium-208",amount:300},
-		fluidOutput: {fluid:"mekanism_extras:polonium-208",amount:300}
-	})
+	customRecipes.mekanism.condensentrating(event,"mekanism_extras:polonium-208",300,"mekanism_extras:polonium-208",300)
 
 	const mekaExtrasTiers = ["absolute", "supreme", "cosmic", "infinite"]
 	

--- a/kubejs/server_scripts/mods/mekanism_extras/mekanism_extras.js
+++ b/kubejs/server_scripts/mods/mekanism_extras/mekanism_extras.js
@@ -4,7 +4,34 @@ ServerEvents.recipes((event) => {
 	removeRecipeByID(event, [
 		M_E("processing/naquadah/ore/end_from_raw"),
 		M_E("expand_radioactive_waste_barrel"),
+		M_E("rotary/polonium_containing"),
+		M_E("rotary/polonium-208"),
 	])
+
+
+	// make it so the naquadah reactor doesn't need  absurd amounts of rotary condensers to fully handle it's output of polonium containing steam
+
+
+	// this one is for steam to solution, normally it goes at 1mb/tick , this would mean you would need 1,500,000 rotary condensers to keep up with the naquadah reactor, and that is absurd
+	// this adjusts it to 5000mb/tick per machine, this lowers it to only needing 300 , this is still a lot but a lot more manageable , also this is assuming max level machines, 16 speed and 16 energy upgrades
+	// no watch of flowing time is taken into account for this , not sure if it affect condensors but it might
+	event.custom({
+		type:"mekanism:rotary",
+		fluidInput: {fluid:"mekanism_extras:polonium_containing_solution",amount:5000},
+		gasOutput: {gas:"mekanism_extras:polonium_containing_steam",amount:5000},
+		gasInput: {gas:"mekanism_extras:polonium_containing_steam",amount:5000},
+		fluidOutput: {fluid:"mekanism_extras:polonium_containing_solution",amount:5000}
+	})
+
+	// this is for going from the liquid polonium 208 to the gas form, this is after the evaporation chamber machine thingy, normally this is again at 1mb/tick per machine
+	// but with a flow rate of 15,000 mb/tick needed, well, 15,000 condensers is again insane, so adjusting them to 300mb/tick per machine means you only need 50 of them for full flow
+	event.custom({
+		type:"mekanism:rotary",
+		fluidInput: {fluid:"mekanism_extras:polonium-208",amount:300},
+		gasOutput: {gas:"mekanism_extras:polonium-208",amount:300},
+		gasInput: {gas:"mekanism_extras:polonium-208",amount:300},
+		fluidOutput: {fluid:"mekanism_extras:polonium-208",amount:300}
+	})
 
 	const mekaExtrasTiers = ["absolute", "supreme", "cosmic", "infinite"]
 	


### PR DESCRIPTION
this makes it so you don't need absurd amounts of rotary condensers to handle the output of the naquadah reactor