### PR TITLE
Create remove_tags.js

### DIFF
--- a/kubejs/server_scripts/fixes/remove_tags.js
+++ b/kubejs/server_scripts/fixes/remove_tags.js
@@ -1,0 +1,7 @@
+ServerEvents.tags('item', event => {
+    //Removes all steel ingots and blocks except mekaism steel from the forge tag to make package crafting recipes easier
+    event.removeAll('forge:storage_blocks/steel'),
+    event.add('forge:storage_blocks/steel', 'mekanism:block_steel'),
+    event.removeAll('forge:ingots/steel'),
+    event.add('forge:ingots/steel', 'mekanism:ingot_seel')
+})


### PR DESCRIPTION
Removes the respective forge steel tags (excluding mekanism) from the blocks and ingots to make package crafting recipes work easier