### PR TITLE
Steel tag fix

### DIFF
--- a/kubejs/server_scripts/fixes/remove_tags.js
+++ b/kubejs/server_scripts/fixes/remove_tags.js
@@ -1,7 +1,0 @@
-ServerEvents.tags('item', event => {
-    //Removes all steel ingots and blocks except mekaism steel from the forge tag to make package crafting recipes easier
-    event.removeAll('forge:storage_blocks/steel'),
-    event.add('forge:storage_blocks/steel', 'mekanism:block_steel'),
-    event.removeAll('forge:ingots/steel'),
-    event.add('forge:ingots/steel', 'mekanism:ingot_seel')
-})

--- a/kubejs/server_scripts/fixes/remove_tags.js
+++ b/kubejs/server_scripts/fixes/remove_tags.js
@@ -1,0 +1,7 @@
+ServerEvents.tags('item', event => {
+    //Removes all steel ingots and blocks except mekaism steel from the forge tag to make package crafting recipes easier
+    event.removeAll('forge:storage_blocks/steel'),
+    event.add('forge:storage_blocks/steel', 'mekanism:block_steel'),
+    event.removeAll('forge:ingots/steel'),
+    event.add('forge:ingots/steel', 'mekanism:ingot_seel')
+})

--- a/kubejs/server_scripts/mods/ad_astra/tags.js
+++ b/kubejs/server_scripts/mods/ad_astra/tags.js
@@ -14,4 +14,7 @@ ServerEvents.tags("item", (event) => {
   event.add(MI_D("doors_big/iron"), AA("iron_sliding_door"));
   
   event.add(MI_D("doors_iron"), AA("steel_door"));
+
+  event.remove(F("storage_blocks/steel"), AA("steel_block"));
+  event.remove(F("ingots/steel"), AA("steel_ingot"));
 });

--- a/kubejs/server_scripts/mods/tconstruct/tags.js
+++ b/kubejs/server_scripts/mods/tconstruct/tags.js
@@ -20,4 +20,7 @@ ServerEvents.tags("item", (event) => {
 	event.add(F("balls"), TCT("ichor_slime_ball"));
 	event.add(F("balls"), TCT("ender_slime_ball"));
 	event.add(F("balls"), TCT("glow_ball"));
+
+	event.remove(F("storage_blocks/steel"), TCT("steel_block"));
+	event.remove(F("ingots/steel"), TCT("steel_ingot"));
 });


### PR DESCRIPTION
Changed to remove the steel tag from the ad astra and tconstruct into their respective mod folders. Did not touch steel nuggets as they are not used.